### PR TITLE
fix: pin swig <4.5 to unblock Python bindings build

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
     - system-mupdf.patch
 
 build:
-  number: 0
+  number: 1
   script:
     - if: unix
       then: LD="$CXX" PYMUPDF_SETUP_MUPDF_BUILD="" PYMUPDF_SETUP_MUPDF_REBUILD=0 PYMUPDF_MUPDF_LIB="$PREFIX/lib" PYMUPDF_INCLUDES="$PREFIX/include:$PREFIX/include/mupdf:$PREFIX/include/freetype2" pip install . -vv --no-deps --no-build-isolation
@@ -38,7 +38,10 @@ requirements:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
     - ${{ stdlib("c") }}
-    - swig
+    # SWIG 4.5.0 dropped the Python 2 -> 3 compatibility shims that PyMuPDF's
+    # src/extra.i relies on, causing 'PyString_FromString' undeclared errors.
+    # Pin below 4.5 until upstream PyMuPDF supports SWIG 4.5.
+    - swig <4.5
     - mupdf =${{ mupdf_version }}
   host:
     - python


### PR DESCRIPTION
## Problem

All CI builds are currently failing across **every** platform (Linux, Windows, macOS, aarch64) when compiling the SWIG-generated Python bindings:

```
src/build/extra.i.cpp:3529:25: error: 'PyString_FromString' was not declared in this scope; did you mean 'PyLong_FromString'?
 3529 |     PyObject* text_py = PyString_FromString(text);
```

Windows gives the MSVC equivalent, `error C3861: 'PyString_FromString': identifier not found`.

`PyString_FromString` is a Python 2 C-API symbol that does not exist in Python 3. It was previously supplied by SWIG's own Python 2 → 3 compatibility shims in `pyhead.swg`.

## Root cause

The recipe declares `swig` with no version pin, so each build solves to the newest SWIG. **SWIG 4.5.0 removes those shims.** From SWIG's `CHANGES.current`:

> Python 2 C API macros removed: … `PyString_FromString` (`PyUnicode_FromString`) …
> \*\*\* POTENTIAL INCOMPATIBILITY \*\*\*

PyMuPDF's `src/extra.i` still calls it (line 228, in `messagev()`), and it is still present on both `1.28.2` and upstream `main` — so this is not yet fixed upstream.

Timeline:

| Event | Date | SWIG | Result |
|-------|------|------|--------|
| Last green build on `main` | 2026-07-01 | 4.4.1 | ✅ |
| SWIG 4.5.0 released | 2026-08-06 | — | — |
| Builds since | 2026-08-11+ | 4.5.0 | ❌ |

This affects `main` / any current build, not just the aarch64 migration PR (#56) where it first surfaced.

Same root cause and same fix as conda-forge/mupdf-feedstock#101.

## Fix

Pin `swig <4.5` (restores 4.4.x, proven working in the 2026-07-01 build) and bump the build number.

A follow-up should track upstream PyMuPDF compatibility with SWIG 4.5 so the pin can be lifted.

> Note: intentionally not re-rendered — this is a build-dependency pin only (`swig` is not a pinned variant), so no CI config changes. Re-rendering on `main` now would also pull in the active aarch64 migration and conflict with #56. #56 will need a rebase once this lands.
